### PR TITLE
PHP 7.4 fix

### DIFF
--- a/src/terminal-style.php
+++ b/src/terminal-style.php
@@ -137,6 +137,6 @@ if ( ! function_exists('terminal_style'))
         }
 
         // Set background
-        return "\e[" . implode($code, ';') . "m" . $message . "\e[0m";
+        return "\e[" . implode(';', $code) . "m" . $message . "\e[0m";
     }
 }


### PR DESCRIPTION
As of 7.4 you can no longer pass the glu after the array, it needs to be in the reverse order

`Passing glue string after array is deprecated. Swap the parameters`